### PR TITLE
mainly fix _newest()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 This file documents the revision history for Perl extension DBIx::Migration.
 
-  - Add support for accepting a dbh.
+0.09 2015-03-09
+     - make psql() accept multiple files
+     - make schema file selection more specific
+
+0.08 no idea
+     - BOM fork
 
 0.07 2010-10-22 
   - Added DBD::SQLite dependency

--- a/META.json
+++ b/META.json
@@ -33,7 +33,7 @@
    "provides" : {
       "DBIx::Migration" : {
          "file" : "lib/DBIx/Migration.pm",
-         "version" : "0.08"
+         "version" : "0.09"
       }
    },
    "release_status" : "stable",
@@ -42,5 +42,5 @@
          "http://dev.perl.org/licenses/"
       ]
    },
-   "version" : "0.08"
+   "version" : "0.09"
 }

--- a/META.yml
+++ b/META.yml
@@ -6,7 +6,7 @@ build_requires: {}
 configure_requires:
   Module::Build: '0.42'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.421, CPAN::Meta::Converter version 2.142690'
+generated_by: 'Module::Build version 0.421, CPAN::Meta::Converter version 2.143240'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -15,7 +15,7 @@ name: DBIx-Migration
 provides:
   DBIx::Migration:
     file: lib/DBIx/Migration.pm
-    version: '0.08'
+    version: '0.09'
 requires:
   DBD::SQLite: '0'
   DBI: '0'
@@ -25,4 +25,4 @@ requires:
   Try::Tiny: '0'
 resources:
   license: http://dev.perl.org/licenses/
-version: '0.08'
+version: '0.09'


### PR DESCRIPTION
- make `_newest()` file selection more specific. Previously, a file
  named for example `.bla_123456789_up.sql` would make `_newest assume`
  the migration target was `123456789`, although that file was a hidden
  file and `_files()` would not find it.
- make `psql()` accept a list of file names. This is a slight optimization
  that avoids creating a separate psql process for each file if you
  want to process many of them.
- bump version number
