### PR TITLE
DBIx::Migration::psql(): clear PERL5* vars before /usr/bin/psql

### DIFF
--- a/lib/DBIx/Migration.pm
+++ b/lib/DBIx/Migration.pm
@@ -288,6 +288,11 @@ sub psql {
 
     local $SIG{PIPE} = 'IGNORE';
 
+    # psql on Debian is a Perl wrapper script, ensure this doesn't carry
+    # any extra environment variables that might reference outside of
+    # Debian's /usr/bin/perl
+    delete @ENV{qw(PERL5OPT PERL5LIB)};
+
     my $pid = open my $psql_in, '|-';    ## no critic
     die "Cannot start psql: $!\n" unless defined $pid;
     unless ($pid) {


### PR DESCRIPTION
Avoid having `PERL5OPT` and `PERL5LIB` in the environment prior to running `/usr/bin/psql`, as in Debian's case, the command is actually a Perl wrapper to determine the latest available version (in the case of multiple installed PostgreSQL versions.)