### PR TITLE
DBIx::Migration::psql(): localize deletion of PERL5* variables

### DIFF
--- a/lib/DBIx/Migration.pm
+++ b/lib/DBIx/Migration.pm
@@ -291,7 +291,7 @@ sub psql {
     # psql on Debian is a Perl wrapper script, ensure this doesn't carry
     # any extra environment variables that might reference outside of
     # Debian's /usr/bin/perl
-    delete @ENV{qw(PERL5OPT PERL5LIB)};
+    delete local @ENV{qw(PERL5OPT PERL5LIB)};
 
     my $pid = open my $psql_in, '|-';    ## no critic
     die "Cannot start psql: $!\n" unless defined $pid;


### PR DESCRIPTION
Especially prevent removal of PERL5LIB here as it may be used elsewhere; instead remove it locally within this function's scope.